### PR TITLE
fix: getComment

### DIFF
--- a/routers/context/getComments.js
+++ b/routers/context/getComments.js
@@ -14,7 +14,7 @@ module.exports = async (ctx, next) => {
 		cid = 205360772,
 		cmd = 8,
 		reqtype = 2,
-		biztype = 2,
+		biztype = 1,
 		rootcommentid = !pagenum && '',
 	} = ctx.query;
 	const checkrootcommentid = !pagenum ? true : !!rootcommentid;


### PR DESCRIPTION
修复获取评论的接口，biztype要设置为1，否则获取的是空数据。