### PR TITLE
修复 docker 镜像构建失败问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:12
+FROM node:22
 
-LABEL maintainer = "Rain120 <1085131904@qq.com>"
+LABEL maintainer="Rain120 <1085131904@qq.com>"
 
 # Create app directory
-WORKDIR /
+WORKDIR /app
 
 COPY package.json .
 
-RUN yarn install --registry=https://registry.npm.taobao.org
+RUN yarn install --registry=https://registry.npmmirror.com
 
 COPY . .
 


### PR DESCRIPTION
1. 更新 node 到最新的 LTS 版本，原有的 node  12 版本已不支持项目里部分的语法
2. 修复 LABEL 语法问题，新版本 key=value 之间不能有空格
3. 更新国内的 npm 源，dockerfile 里面的源（`https://registry.npm.taobao.org`）已于 2022 年下线
4. WORKDIR 改为`/app`，原有的放在根目录的做法不合适